### PR TITLE
Changed info message order in discover phase

### DIFF
--- a/tellsticknet/discovery.py
+++ b/tellsticknet/discovery.py
@@ -32,13 +32,13 @@ def discover(timeout=DISCOVERY_TIMEOUT):
 
                 (product, mac, code, firmware) = entry
 
+                _LOGGER.info("Found %s device with firmware %s at %s",
+                    product, firmware, address)
                 if product != PRODUCT_TELLSTICK_NET:
                     _LOGGER.info("Unsupported product %s", product)
                 elif int(firmware) < MIN_FIRMWARE_VERSION:
                     _LOGGER.info("Unsupported firmware version: %s", firmware)
                 else:
-                    _LOGGER.info("Found %s device with firmware %s at %s",
-                                 product, firmware, address)
                     # _LOGGER.debug("Activation code %s", code)
                     yield address, entry
 


### PR DESCRIPTION
I had to change the order of the `Found device` as my Tellstick NET had firmware v4 and I thinks it makes sense to display the info even if the device is not supported.