### PR TITLE
Fixes for packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,16 @@ setup(name='tellsticknet',
       author='Erik Eriksson',
       author_email='error.errorsson@gmail.com',
       keywords='tellstick',
-      packages=['tellsticknet'],
+      packages=setuptools.find_packages(),
       long_description=(open('README.md').read()
                         if exists('README.md') else ''),
       install_requires=list(
           open('requirements.txt').read().strip().split('\n')),
       scripts=[],
       extras_require={},
+      entry_points={
+          'console_scripts': [
+              'tellsticknet=tellsticknet.__main__:app_main' ,
+          ],
+      },
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup
+from setuptools import setup, find_packages
 from os.path import exists
 
 
@@ -12,7 +12,7 @@ setup(name='tellsticknet',
       author='Erik Eriksson',
       author_email='error.errorsson@gmail.com',
       keywords='tellstick',
-      packages=setuptools.find_packages(),
+      packages=find_packages(),
       long_description=(open('README.md').read()
                         if exists('README.md') else ''),
       install_requires=list(

--- a/tellsticknet/__main__.py
+++ b/tellsticknet/__main__.py
@@ -231,8 +231,7 @@ async def main(args):
             ]
         )
 
-
-if __name__ == "__main__":
+def app_main():
     args = docopt.docopt(__doc__, version=__version__)
 
     debug = args["-d"]
@@ -263,3 +262,6 @@ if __name__ == "__main__":
         asyncio.run(main(args), debug=debug)  # pylint: disable=no-member
     except KeyboardInterrupt:
         exit()
+
+if __name__ == "__main__":
+    app_main()

--- a/tellsticknet/__main__.py
+++ b/tellsticknet/__main__.py
@@ -231,6 +231,7 @@ async def main(args):
             ]
         )
 
+
 def app_main():
     args = docopt.docopt(__doc__, version=__version__)
 
@@ -262,6 +263,7 @@ def app_main():
         asyncio.run(main(args), debug=debug)  # pylint: disable=no-member
     except KeyboardInterrupt:
         exit()
+
 
 if __name__ == "__main__":
     app_main()


### PR DESCRIPTION
Added console_scripts entry to setup.py, this required a slight
refactoring of __main__.py.
Also adjusted the packages field in setup.py so it includes not only
the tellsticknet package but also tellsticknet.protocols.

Now the package can be installed with pip and the tellsticknet command
will be available on the PATH.