### PR TITLE
tellsticknet-sample.conf syntax fix

### DIFF
--- a/tellsticknet-sample.conf
+++ b/tellsticknet-sample.conf
@@ -1,3 +1,4 @@
+---
 # a binary sensor
 name: Door
 component: binary_sensor
@@ -42,7 +43,7 @@ class: sensor  # optional
 protocol: fineoffset
 model: temperaturehumidity
 sensorId: 181
---
+---
 # a light responding to two commands
 name: Bedroom
 component: light
@@ -51,7 +52,7 @@ model: selflearning-dimmer
 unit: 1
 house: 11408680
 aliases:
-- protocol: arctech
-  model: selflearning
-  unit: 14
-  house: 45213518
+  - protocol: arctech
+    model: selflearning
+    unit: 14
+    house: 45213518


### PR DESCRIPTION
Fixed a syntax error and a couple of yamllint warnings.