### PR TITLE
Check for MQTT_URL env var before reading mosquitto_pub

### DIFF
--- a/tellsticknet/mqtt.py
+++ b/tellsticknet/mqtt.py
@@ -96,19 +96,33 @@ def method_for_str(s):
 
 
 def read_credentials():
-    """Read credentials from ~/.config/mosquitto_pub."""
-    with open(
-        join(
-            env.get("XDG_CONFIG_HOME", join(expanduser("~"), ".config")),
-            "mosquitto_pub",
-        )
-    ) as f:
-        d = dict(
-            line.replace("-", "").split() for line in f.read().splitlines()
-        )
-        return dict(
-            host=d["h"], port=d["p"], username=d["username"], password=d["pw"]
-        )
+    """Read credentials from $MQTT_URL or ~/.config/mosquitto_pub.
+
+    MQTT_URL examples:
+        mqtt://localhost
+        mqtts://username:password@host:port
+
+    """
+    mqtt_url = env.get("MQTT_URL")
+    if mqtt_url:
+        credentials = dict(url=mqtt_url)
+    else:
+        with open(
+            join(
+                env.get("XDG_CONFIG_HOME", join(expanduser("~"), ".config")),
+                "mosquitto_pub",
+            )
+        ) as f:
+            d = dict(
+                line.replace("-", "").split() for line in f.read().splitlines()
+            )
+            credentials = dict(
+                host=d["h"],
+                port=d["p"],
+                username=d["username"],
+                password=d["pw"],
+            )
+    return credentials
 
 
 def whitelisted(


### PR DESCRIPTION
Alternative to using mosquitto_pub, specifying the URL is also more flexible, user/pass is optional and
the port number do not control the protocol used.

MQTT_URL examples:
  mqtt://localhost
  mqtts://username:password@host:port