### PR TITLE
Fix license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
     version="0.1.2",
     description="Listen for UDP sensor broadcasts from a Tellstick",
     url="https://github.com/molobrakos/tellsticknet",
-    license="?",
     author="Erik Eriksson",
     author_email="error.errorsson@gmail.com",
     keywords="tellstick",
@@ -22,4 +21,7 @@ setup(
         "console_scripts": ["tellsticknet=tellsticknet.__main__:app_main"]
     },
     zip_safe=False,
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+    ],
 )


### PR DESCRIPTION
Hey 👋🏻,

I am currently looking into licensing at Home Assistant, and I found that we could not detect the license of this library properly. According to pyproject.toml documentation about the `license` field:
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with License ::. (As a general rule, it is a good idea to use a standard, well-known license, both to avoid confusion and because some organizations avoid software whose license is unapproved.)

If you could do a release after this PR, and maybe bump in Home Assistant, that would be awesome :)